### PR TITLE
fix(backend): fix null check for transaction relations

### DIFF
--- a/backend/src/accounting/expense/expense.service.ts
+++ b/backend/src/accounting/expense/expense.service.ts
@@ -141,7 +141,7 @@ export class ExpenseService {
     const expenseEntity = await this.getEntityOrThrow(user, id);
 
     this.mapData(user, expenseEntity, input);
-    if (expenseEntity.transaction !== undefined) {
+    if (expenseEntity.transaction) {
       expenseEntity.transaction.id = expenseEntity.transactionId;
     }
 
@@ -202,7 +202,7 @@ export class ExpenseService {
       }
     });
 
-    if (expense.transaction !== undefined) {
+    if (expense.transaction) {
       expense.transaction.propertyId = expense.propertyId;
       expense.transaction.property = expense.property;
       // Copy accountingDate from transaction if not explicitly set
@@ -210,7 +210,7 @@ export class ExpenseService {
         expense.accountingDate = expense.transaction.accountingDate;
       }
     }
-    if (expense.expenseType !== undefined) {
+    if (expense.expenseType) {
       expense.expenseType.userId = user.id;
     }
   }

--- a/backend/src/accounting/income/income.service.ts
+++ b/backend/src/accounting/income/income.service.ts
@@ -138,7 +138,7 @@ export class IncomeService {
     const incomeEntity = await this.getEntityOrThrow(user, id);
 
     this.mapData(incomeEntity, input);
-    if (incomeEntity.transaction !== undefined) {
+    if (incomeEntity.transaction) {
       incomeEntity.transaction.id = incomeEntity.transactionId;
     }
 
@@ -166,7 +166,7 @@ export class IncomeService {
       }
     });
 
-    if (income.transaction !== undefined) {
+    if (income.transaction) {
       income.transaction.propertyId = income.propertyId;
       income.transaction.property = income.property;
       // Copy accountingDate from transaction if not explicitly set


### PR DESCRIPTION
## Summary
- Fixed TypeError when updating expense/income types after creation
- The condition `!== undefined` incorrectly passed when `transaction` was `null`
- Changed to truthy checks to properly handle both `null` and `undefined` cases

## Root Cause
The nullable `transaction` relation could be `null` (not just `undefined`). The check `transaction !== undefined` evaluates to `true` when transaction is `null`, causing the code to try setting properties on `null`.

## Files Changed
- `expense.service.ts` - 3 occurrences fixed
- `income.service.ts` - 2 occurrences fixed

## Test plan
- [x] All existing expense and income service tests pass
- [x] All backend unit tests pass (355 tests)