### PR TITLE
fix(menu): improve left menu toggle icons with descriptive tooltips

### DIFF
--- a/frontend/src/components/layout/LeftMenu.tsx
+++ b/frontend/src/components/layout/LeftMenu.tsx
@@ -1,8 +1,10 @@
 import { styled } from "@mui/material/styles";
-import { Divider, IconButton, Toolbar } from "@mui/material";
+import { Divider, IconButton, Toolbar, Tooltip } from "@mui/material";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import MenuIcon from "@mui/icons-material/Menu";
 import MuiDrawer from "@mui/material/Drawer";
 import LeftMenuItems from "./LeftMenuItems";
+import { useTranslation } from "react-i18next";
 
 const drawerWidth: number = 240;
 const collapsedWidth: number = 72;
@@ -37,6 +39,8 @@ interface LeftMenuProps {
 }
 
 function LeftMenu({ open, onToggleDrawer, isMobile = false }: LeftMenuProps) {
+  const { t } = useTranslation("menu");
+
   if (isMobile) {
     // Mobile: Temporary drawer overlay, no permanent sidebar
     return (
@@ -60,9 +64,11 @@ function LeftMenu({ open, onToggleDrawer, isMobile = false }: LeftMenuProps) {
             px: [1],
           }}
         >
-          <IconButton onClick={onToggleDrawer}>
-            <ChevronLeftIcon />
-          </IconButton>
+          <Tooltip title={t("collapseMenu")}>
+            <IconButton onClick={onToggleDrawer}>
+              <ChevronLeftIcon />
+            </IconButton>
+          </Tooltip>
         </Toolbar>
         <Divider />
         <LeftMenuItems open={true} isMobile={true} />
@@ -81,9 +87,11 @@ function LeftMenu({ open, onToggleDrawer, isMobile = false }: LeftMenuProps) {
           px: [1],
         }}
       >
-        <IconButton onClick={onToggleDrawer}>
-          <ChevronLeftIcon />
-        </IconButton>
+        <Tooltip title={open ? t("collapseMenu") : t("expandMenu")}>
+          <IconButton onClick={onToggleDrawer}>
+            {open ? <ChevronLeftIcon /> : <MenuIcon />}
+          </IconButton>
+        </Tooltip>
       </Toolbar>
       <Divider />
       <LeftMenuItems open={open} isMobile={false} />

--- a/frontend/src/translations/menu/en.ts
+++ b/frontend/src/translations/menu/en.ts
@@ -5,6 +5,8 @@ const menu = {
   accounting: "Accounting",
   transactions: "Transactions",
   taxes: "Taxes",
+  expandMenu: "Expand menu",
+  collapseMenu: "Collapse menu",
 };
 
 export default menu;

--- a/frontend/src/translations/menu/fi.ts
+++ b/frontend/src/translations/menu/fi.ts
@@ -5,6 +5,8 @@ const menu = {
     accounting: 'Kirjanpito',
     transactions: 'Tilitapahtumat',
     taxes: 'Verot',
+    expandMenu: 'Laajenna valikko',
+    collapseMenu: 'Pienennä valikko',
 }
 
 export default menu

--- a/frontend/src/translations/menu/sv.ts
+++ b/frontend/src/translations/menu/sv.ts
@@ -5,6 +5,8 @@ const menu = {
     accounting: 'Bokföring',
     transactions: 'Transaktioner',
     taxes: 'Skatter',
+    expandMenu: 'Expandera meny',
+    collapseMenu: 'Minimera meny',
 }
 
 export default menu


### PR DESCRIPTION
## Summary
- Use hamburger icon (☰) for expanding collapsed menu instead of arrow left
- Use chevron left (←) for collapsing expanded menu
- Add tooltips to both icons explaining the action
- Translations added for EN, FI, and SV

## Test plan
- [ ] Collapse the menu on desktop - verify chevron left icon with "Collapse menu" tooltip
- [ ] Click hamburger icon on collapsed menu - verify it expands with "Expand menu" tooltip
- [ ] Test tooltip translations by switching language

Closes #27