### PR TITLE
fix(frontend): resolve TypeScript build errors

### DIFF
--- a/frontend/src/components/accounting/expenses/Expenses.test.tsx
+++ b/frontend/src/components/accounting/expenses/Expenses.test.tsx
@@ -147,7 +147,18 @@ describe('Expenses Component Logic', () => {
   });
 
   describe('rowDataService transformation', () => {
-    const mockExpense = {
+    interface MockExpense {
+      id: number;
+      accountingDate: Date | null;
+      expenseType?: { id: number; name: string };
+      description: string;
+      quantity: number;
+      amount: number;
+      totalAmount: number;
+      property: { id: number; name: string };
+    }
+
+    const mockExpense: MockExpense = {
       id: 1,
       accountingDate: new Date('2024-03-15'),
       expenseType: { id: 1, name: 'Utilities' },
@@ -194,7 +205,7 @@ describe('Expenses Component Logic', () => {
     });
 
     it('handles missing expenseType', () => {
-      const expense = { ...mockExpense, expenseType: undefined };
+      const expense: MockExpense = { ...mockExpense, expenseType: undefined };
       const row: ExpenseRow = {
         id: expense.id,
         accountingDate: expense.accountingDate || null,

--- a/frontend/src/components/accounting/incomes/Incomes.test.tsx
+++ b/frontend/src/components/accounting/incomes/Incomes.test.tsx
@@ -147,7 +147,18 @@ describe('Incomes Component Logic', () => {
   });
 
   describe('rowDataService transformation', () => {
-    const mockIncome = {
+    interface MockIncome {
+      id: number;
+      accountingDate: Date | null;
+      incomeType?: { id: number; name: string };
+      description: string;
+      quantity: number;
+      amount: number;
+      totalAmount: number;
+      property: { id: number; name: string };
+    }
+
+    const mockIncome: MockIncome = {
       id: 1,
       accountingDate: new Date('2024-03-15'),
       incomeType: { id: 1, name: 'Rent' },
@@ -194,7 +205,7 @@ describe('Incomes Component Logic', () => {
     });
 
     it('handles missing incomeType', () => {
-      const income = { ...mockIncome, incomeType: undefined };
+      const income: MockIncome = { ...mockIncome, incomeType: undefined };
       const row: IncomeRow = {
         id: income.id,
         accountingDate: income.accountingDate || null,

--- a/frontend/src/components/admin/AdminMenu.test.tsx
+++ b/frontend/src/components/admin/AdminMenu.test.tsx
@@ -63,7 +63,7 @@ describe('AdminMenu', () => {
 
     it('does not render when isAdmin is undefined', async () => {
       const userWithoutAdmin = { ...mockNonAdminUser, isAdmin: undefined };
-      jest.spyOn(ApiClient, 'me').mockResolvedValue(userWithoutAdmin as ReturnType<typeof createMockUser>);
+      jest.spyOn(ApiClient, 'me').mockResolvedValue(userWithoutAdmin as unknown as ReturnType<typeof createMockUser>);
 
       const { container } = renderWithProviders(<AdminMenu />);
 

--- a/frontend/src/components/admin/tiers/AdminTierList.test.tsx
+++ b/frontend/src/components/admin/tiers/AdminTierList.test.tsx
@@ -305,7 +305,7 @@ describe('AdminTierList Logic', () => {
       let tiers = [{ id: 1, name: 'Original' }];
       const responseOk = false;
 
-      const handleResponse = (ok: boolean, data: unknown[]) => {
+      const handleResponse = (ok: boolean, data: { id: number; name: string }[]) => {
         if (ok) {
           tiers = data;
         }

--- a/frontend/src/components/admin/users/AdminUserList.test.tsx
+++ b/frontend/src/components/admin/users/AdminUserList.test.tsx
@@ -301,7 +301,7 @@ describe('AdminUserList Logic', () => {
     it('does not update on failed response', () => {
       let users = [{ id: 1, firstName: 'Original' }];
 
-      const handleResponse = (ok: boolean, data: unknown[]) => {
+      const handleResponse = (ok: boolean, data: { id: number; firstName: string }[]) => {
         if (ok) {
           users = data;
         }
@@ -328,7 +328,12 @@ describe('AdminUserList Logic', () => {
 
   describe('User tier update optimistic UI', () => {
     it('updates local state before waiting for API response', () => {
-      let users = [
+      interface UserWithTier {
+        id: number;
+        tierId: number;
+        tier: { id: number; name: string } | undefined;
+      }
+      let users: UserWithTier[] = [
         { id: 1, tierId: 1, tier: { id: 1, name: 'Free' } },
       ];
       const tiers = [

--- a/frontend/src/components/alisa/AlisaCardList.test.tsx
+++ b/frontend/src/components/alisa/AlisaCardList.test.tsx
@@ -5,13 +5,26 @@ import { renderWithProviders } from '@test-utils/test-wrapper';
 import AlisaCardList from './AlisaCardList';
 import ApiClient from '@alisa-lib/api-client';
 import { propertyContext } from '@alisa-lib/alisa-contexts';
+import { TFunction } from 'i18next';
 
 // Mock ApiClient static methods
 jest.spyOn(ApiClient, 'search');
 jest.spyOn(ApiClient, 'delete');
 
+interface TestProperty {
+  id: number;
+  name: string;
+  size: number;
+  description: string;
+  address: string;
+  city: string;
+  postalCode: string;
+  buildYear: number;
+  ownerships: { share: number }[];
+}
+
 describe('AlisaCardList', () => {
-  const mockT = (key: string) => {
+  const mockT = ((key: string) => {
     const translations: Record<string, string> = {
       add: 'Add',
       edit: 'Edit',
@@ -26,7 +39,7 @@ describe('AlisaCardList', () => {
       noDescription: 'No description',
     };
     return translations[key] || key;
-  };
+  }) as TFunction;
 
   const mockProperties = [
     {
@@ -62,14 +75,14 @@ describe('AlisaCardList', () => {
   });
 
   it('renders loading and then displays items', async () => {
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue(mockProperties);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue(mockProperties);
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }, { name: 'size' }]}
+        fields={[{ name: 'name' as keyof TestProperty }, { name: 'size' as keyof TestProperty }]}
       />
     );
 
@@ -81,14 +94,14 @@ describe('AlisaCardList', () => {
   });
 
   it('displays property details correctly', async () => {
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue(mockProperties);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue(mockProperties);
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }, { name: 'size' }]}
+        fields={[{ name: 'name' as keyof TestProperty }, { name: 'size' as keyof TestProperty }]}
       />
     );
 
@@ -109,14 +122,14 @@ describe('AlisaCardList', () => {
   });
 
   it('displays empty state when no items', async () => {
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue([]);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue([]);
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }]}
+        fields={[{ name: 'name' as keyof TestProperty }]}
       />
     );
 
@@ -127,14 +140,14 @@ describe('AlisaCardList', () => {
 
   it('opens delete confirmation dialog', async () => {
     const user = userEvent.setup();
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue(mockProperties);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue(mockProperties);
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }]}
+        fields={[{ name: 'name' as keyof TestProperty }]}
       />
     );
 
@@ -150,14 +163,14 @@ describe('AlisaCardList', () => {
 
   it('closes delete dialog on cancel', async () => {
     const user = userEvent.setup();
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue(mockProperties);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue(mockProperties);
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }]}
+        fields={[{ name: 'name' as keyof TestProperty }]}
       />
     );
 
@@ -178,15 +191,15 @@ describe('AlisaCardList', () => {
 
   it('deletes item when confirmed', async () => {
     const user = userEvent.setup();
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue(mockProperties);
-    (ApiClient.delete as jest.SpyInstance).mockResolvedValue({});
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue(mockProperties);
+    (ApiClient.delete as unknown as jest.SpyInstance).mockResolvedValue({});
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }]}
+        fields={[{ name: 'name' as keyof TestProperty }]}
       />
     );
 
@@ -198,7 +211,7 @@ describe('AlisaCardList', () => {
     await user.click(deleteButtons[0]);
 
     // Update mock to return fewer items after delete
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue([mockProperties[1]]);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue([mockProperties[1]]);
 
     // Click the delete button in the dialog
     const allDeleteButtons = screen.getAllByRole('button', { name: /delete/i });
@@ -211,15 +224,15 @@ describe('AlisaCardList', () => {
   });
 
   it('calls API with correct parameters', async () => {
-    const fetchOptions = { order: { name: 'ASC' } };
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue([]);
+    const fetchOptions = { order: { name: 'ASC' as const } };
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue([]);
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }]}
+        fields={[{ name: 'name' as keyof TestProperty }]}
         fetchOptions={fetchOptions}
       />
     );
@@ -234,15 +247,15 @@ describe('AlisaCardList', () => {
 
   it('refetches data after deletion', async () => {
     const user = userEvent.setup();
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue(mockProperties);
-    (ApiClient.delete as jest.SpyInstance).mockResolvedValue({});
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue(mockProperties);
+    (ApiClient.delete as unknown as jest.SpyInstance).mockResolvedValue({});
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }]}
+        fields={[{ name: 'name' as keyof TestProperty }]}
       />
     );
 
@@ -256,7 +269,7 @@ describe('AlisaCardList', () => {
     const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
     await user.click(deleteButtons[0]);
 
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue([mockProperties[1]]);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue([mockProperties[1]]);
 
     const allDeleteButtons = screen.getAllByRole('button', { name: /delete/i });
     const confirmButton = allDeleteButtons[allDeleteButtons.length - 1];
@@ -269,14 +282,14 @@ describe('AlisaCardList', () => {
   });
 
   it('displays add link', async () => {
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue(mockProperties);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue(mockProperties);
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }]}
+        fields={[{ name: 'name' as keyof TestProperty }]}
       />
     );
 
@@ -289,14 +302,14 @@ describe('AlisaCardList', () => {
   });
 
   it('displays title', async () => {
-    (ApiClient.search as jest.SpyInstance).mockResolvedValue([]);
+    (ApiClient.search as unknown as jest.SpyInstance).mockResolvedValue([]);
 
     renderWithProviders(
       <AlisaCardList
         t={mockT}
         title="My Properties"
         alisaContext={propertyContext}
-        fields={[{ name: 'name' }]}
+        fields={[{ name: 'name' as keyof TestProperty }]}
       />
     );
 

--- a/frontend/src/components/alisa/data/AlisaTransactionStatusSelect.test.tsx
+++ b/frontend/src/components/alisa/data/AlisaTransactionStatusSelect.test.tsx
@@ -3,16 +3,17 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { renderWithProviders } from '@test-utils/test-wrapper';
 import AlisaTransactionStatusSelect from './AlisaTransactionStatusSelect';
+import { TFunction } from 'i18next';
 
 describe('AlisaTransactionStatusSelect', () => {
-  const mockT = (key: string) => {
+  const mockT = ((key: string) => {
     const translations: Record<string, string> = {
       pending: 'Pending',
       accepted: 'Accepted',
       transactionStatus: 'Transaction Status',
     };
     return translations[key] || key;
-  };
+  }) as TFunction;
 
   it('renders and becomes ready', async () => {
     // Component may render loading briefly or skip it in test environment

--- a/frontend/src/components/alisa/data/AlisaTransactionTypeSelect.test.tsx
+++ b/frontend/src/components/alisa/data/AlisaTransactionTypeSelect.test.tsx
@@ -3,9 +3,10 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { renderWithProviders } from '@test-utils/test-wrapper';
 import AlisaTransactionTypeSelect from './AlisaTransactionTypeSelect';
+import { TFunction } from 'i18next';
 
 describe('AlisaTransactionTypeSelect', () => {
-  const mockT = (key: string) => {
+  const mockT = ((key: string) => {
     const translations: Record<string, string> = {
       unknown: 'Unknown',
       income: 'Income',
@@ -16,7 +17,7 @@ describe('AlisaTransactionTypeSelect', () => {
       loading: 'Loading...',
     };
     return translations[key] || key;
-  };
+  }) as TFunction;
 
   it('renders and becomes ready', async () => {
     // Component may render loading briefly or skip it in test environment

--- a/frontend/src/components/dashboard/Dashboard.test.tsx
+++ b/frontend/src/components/dashboard/Dashboard.test.tsx
@@ -329,7 +329,7 @@ describe('Dashboard Component Logic', () => {
     });
 
     it('year selector hidden in yearly mode', () => {
-      const viewMode = 'yearly';
+      const viewMode = 'yearly' as 'monthly' | 'yearly';
       const visibility = viewMode === 'monthly' ? 'visible' : 'hidden';
 
       expect(visibility).toBe('hidden');

--- a/frontend/src/components/dashboard/config/widget-registry.test.ts
+++ b/frontend/src/components/dashboard/config/widget-registry.test.ts
@@ -204,7 +204,7 @@ describe('widget-registry', () => {
 
     it('size is optional', () => {
       const configWithSize = { id: 'test', visible: true, order: 0, size: '1/2' as WidgetSize };
-      const configWithoutSize = { id: 'test', visible: true, order: 0 };
+      const configWithoutSize: { id: string; visible: boolean; order: number; size?: WidgetSize } = { id: 'test', visible: true, order: 0 };
 
       expect(configWithSize.size).toBe('1/2');
       expect(configWithoutSize.size).toBeUndefined();

--- a/frontend/src/components/dashboard/context/DashboardContext.test.tsx
+++ b/frontend/src/components/dashboard/context/DashboardContext.test.tsx
@@ -46,7 +46,7 @@ describe('DashboardContext Logic', () => {
     });
 
     it('keeps non-zero property ID as is', () => {
-      const propertyId = 5;
+      const propertyId: number = 5;
       const selectedPropertyId = propertyId === 0 ? null : propertyId;
 
       expect(selectedPropertyId).toBe(5);

--- a/frontend/src/components/datatables/Orders.test.tsx
+++ b/frontend/src/components/datatables/Orders.test.tsx
@@ -4,7 +4,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '@test-utils/test-wrapper';
 import ApiClient from '@alisa-lib/api-client';
-import { Expense } from '@alisa-types';
+import { Expense, TransactionStatus, TransactionType } from '@alisa-types';
 import Orders from './Orders';
 
 describe('Orders Component', () => {
@@ -30,8 +30,8 @@ describe('Orders Component', () => {
       transaction: {
         id: 1,
         externalId: 'ext-001',
-        status: 'ACCEPTED' as const,
-        type: 'EXPENSE' as const,
+        status: TransactionStatus.ACCEPTED,
+        type: TransactionType.EXPENSE,
         sender: 'Property Account',
         receiver: 'Electric Company',
         description: 'Monthly electricity',
@@ -63,8 +63,8 @@ describe('Orders Component', () => {
       transaction: {
         id: 2,
         externalId: 'ext-002',
-        status: 'ACCEPTED' as const,
-        type: 'EXPENSE' as const,
+        status: TransactionStatus.ACCEPTED,
+        type: TransactionType.EXPENSE,
         sender: 'Property Account',
         receiver: 'Water Company',
         description: 'Quarterly water',

--- a/frontend/src/components/investment-calculator/InvestmentCalculationEditDialog.test.tsx
+++ b/frontend/src/components/investment-calculator/InvestmentCalculationEditDialog.test.tsx
@@ -52,7 +52,7 @@ describe('InvestmentCalculationEditDialog', () => {
   });
 
   it('shows loading state initially', async () => {
-    (ApiClient.get as jest.SpyInstance).mockImplementation(() => new Promise(() => {}));
+    (ApiClient.get as unknown as jest.SpyInstance).mockImplementation(() => new Promise(() => {}));
 
     renderWithProviders(
       <InvestmentCalculationEditDialog
@@ -66,7 +66,7 @@ describe('InvestmentCalculationEditDialog', () => {
   });
 
   it('calls API with correct calculation ID', async () => {
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationEditDialog
@@ -107,7 +107,7 @@ describe('InvestmentCalculationEditDialog', () => {
 
   it('calls onClose when dialog is closed via Escape', async () => {
     const mockOnClose = jest.fn();
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationEditDialog
@@ -129,7 +129,7 @@ describe('InvestmentCalculationEditDialog', () => {
 
   it('handles API error gracefully', async () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    (ApiClient.get as jest.SpyInstance).mockRejectedValue(new Error('API Error'));
+    (ApiClient.get as unknown as jest.SpyInstance).mockRejectedValue(new Error('API Error'));
 
     renderWithProviders(
       <InvestmentCalculationEditDialog
@@ -147,7 +147,7 @@ describe('InvestmentCalculationEditDialog', () => {
   });
 
   it('renders dialog when open and loaded', async () => {
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationEditDialog
@@ -163,7 +163,7 @@ describe('InvestmentCalculationEditDialog', () => {
   });
 
   it('displays calculation name in title after loading', async () => {
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationEditDialog

--- a/frontend/src/components/investment-calculator/InvestmentCalculationViewDialog.test.tsx
+++ b/frontend/src/components/investment-calculator/InvestmentCalculationViewDialog.test.tsx
@@ -50,7 +50,7 @@ describe('InvestmentCalculationViewDialog', () => {
   });
 
   it('shows loading state initially', async () => {
-    (ApiClient.get as jest.SpyInstance).mockImplementation(() => new Promise(() => {}));
+    (ApiClient.get as unknown as jest.SpyInstance).mockImplementation(() => new Promise(() => {}));
 
     renderWithProviders(
       <InvestmentCalculationViewDialog
@@ -64,7 +64,7 @@ describe('InvestmentCalculationViewDialog', () => {
   });
 
   it('calls API with correct calculation ID', async () => {
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationViewDialog
@@ -105,7 +105,7 @@ describe('InvestmentCalculationViewDialog', () => {
 
   it('calls onClose when dialog is closed via Escape', async () => {
     const mockOnClose = jest.fn();
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationViewDialog
@@ -127,7 +127,7 @@ describe('InvestmentCalculationViewDialog', () => {
 
   it('handles API error gracefully', async () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    (ApiClient.get as jest.SpyInstance).mockRejectedValue(new Error('API Error'));
+    (ApiClient.get as unknown as jest.SpyInstance).mockRejectedValue(new Error('API Error'));
 
     renderWithProviders(
       <InvestmentCalculationViewDialog
@@ -145,7 +145,7 @@ describe('InvestmentCalculationViewDialog', () => {
   });
 
   it('renders dialog when open and loaded', async () => {
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationViewDialog
@@ -161,7 +161,7 @@ describe('InvestmentCalculationViewDialog', () => {
   });
 
   it('displays calculation name in title after loading', async () => {
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationViewDialog
@@ -179,7 +179,7 @@ describe('InvestmentCalculationViewDialog', () => {
   });
 
   it('does not show save button in view mode', async () => {
-    (ApiClient.get as jest.SpyInstance).mockResolvedValue(mockCalculation);
+    (ApiClient.get as unknown as jest.SpyInstance).mockResolvedValue(mockCalculation);
 
     renderWithProviders(
       <InvestmentCalculationViewDialog

--- a/frontend/src/components/landing/LandingPage.tsx
+++ b/frontend/src/components/landing/LandingPage.tsx
@@ -46,7 +46,8 @@ function LandingPage({ t }: WithTranslation) {
   const handleCalculate = async (data: InvestmentInputData) => {
     try {
       setInputData(data);
-      const response = await ApiClient.post<InvestmentResults | { data: InvestmentResults }>(
+      // Use 'unknown' as input type since the response type differs from input type
+      const response = await ApiClient.post<unknown>(
         'real-estate/investment/calculate',
         data,
         true

--- a/frontend/src/components/layout/LanguageSelector.tsx
+++ b/frontend/src/components/layout/LanguageSelector.tsx
@@ -4,6 +4,7 @@ import { MenuItem, Box, Menu, Fade, IconButton, Tooltip, styled, Avatar, Stack }
 import CheckIcon from '@mui/icons-material/Check';
 import useIsAuthenticated from 'react-auth-kit/hooks/useIsAuthenticated';
 import ApiClient from '@alisa-lib/api-client';
+import { SupportedLanguage } from '@alisa-types';
 
 const SmallAvatar = styled(Avatar)(({ theme }) => ({
     width: 24,
@@ -38,7 +39,7 @@ function LanguageSelector({ t }: WithTranslation) {
         setAnchorEl(null);
     };
 
-    const changeLanguage = async (language: string) => {
+    const changeLanguage = async (language: SupportedLanguage) => {
         i18n.changeLanguage(language);
         handleClose();
 
@@ -55,7 +56,7 @@ function LanguageSelector({ t }: WithTranslation) {
         return language == i18n.language ? 'visible' : 'hidden'
     };
 
-    const getMenuItem = (language: string, languageText: string) => {
+    const getMenuItem = (language: SupportedLanguage, languageText: string) => {
         return (
             <MenuItem onClick={() => changeLanguage(language)}>
                 <Stack direction={'row'} spacing={2}>

--- a/frontend/src/components/property/Properties.test.tsx
+++ b/frontend/src/components/property/Properties.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { Property } from '@alisa-types';
+import { Ownership, Property } from '@alisa-types';
 
 // Since Jest mock hoisting causes issues with relative paths in ESM mode,
 // we test the data transformation logic separately from the React component
@@ -14,7 +14,7 @@ describe('Properties Component Logic', () => {
       city: 'Helsinki',
       postalCode: '00100',
       description: 'A nice apartment',
-      ownerships: [{ share: 100, userId: 1 }],
+      ownerships: [{ share: 100, userId: 1, propertyId: 1 }],
     },
     {
       id: 2,
@@ -22,7 +22,7 @@ describe('Properties Component Logic', () => {
       address: '456 Another Street',
       city: 'Espoo',
       postalCode: '02100',
-      ownerships: [{ share: 50, userId: 1 }],
+      ownerships: [{ share: 50, userId: 1, propertyId: 2 }],
     },
   ];
 
@@ -247,7 +247,7 @@ describe('Properties Component Logic', () => {
 
     it('returns undefined when no ownerships', () => {
       const property = {
-        ownerships: [],
+        ownerships: [] as Ownership[],
       };
 
       const getOwnershipShare = () => {

--- a/frontend/src/components/property/PropertyForm.test.tsx
+++ b/frontend/src/components/property/PropertyForm.test.tsx
@@ -1,12 +1,17 @@
 import '@testing-library/jest-dom';
-import { PropertyInputDto } from '@alisa-types';
+import { PropertyInput } from '@alisa-types';
 
 // Since Jest mock hoisting causes issues with relative paths in ESM mode,
 // we test the data transformation logic separately from the React component
 // Following the same pattern as Transactions.test.tsx
 
+// Extended type for form that includes optional id (for edit mode)
+interface PropertyFormData extends PropertyInput {
+  id?: number;
+}
+
 describe('PropertyForm Component Logic', () => {
-  const defaultPropertyInput: PropertyInputDto = {
+  const defaultPropertyInput: PropertyFormData = {
     id: 0,
     name: '',
     size: 0,
@@ -45,10 +50,10 @@ describe('PropertyForm Component Logic', () => {
   describe('Form data update logic', () => {
     it('updates name field correctly', () => {
       const updateField = (
-        data: PropertyInputDto,
-        field: keyof PropertyInputDto,
+        data: PropertyFormData,
+        field: keyof PropertyFormData,
         value: unknown
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, [field]: value };
       };
 
@@ -58,10 +63,10 @@ describe('PropertyForm Component Logic', () => {
 
     it('updates size field correctly', () => {
       const updateField = (
-        data: PropertyInputDto,
-        field: keyof PropertyInputDto,
+        data: PropertyFormData,
+        field: keyof PropertyFormData,
         value: unknown
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, [field]: value };
       };
 
@@ -71,10 +76,10 @@ describe('PropertyForm Component Logic', () => {
 
     it('updates address field correctly', () => {
       const updateField = (
-        data: PropertyInputDto,
-        field: keyof PropertyInputDto,
+        data: PropertyFormData,
+        field: keyof PropertyFormData,
         value: unknown
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, [field]: value };
       };
 
@@ -88,10 +93,10 @@ describe('PropertyForm Component Logic', () => {
 
     it('updates city field correctly', () => {
       const updateField = (
-        data: PropertyInputDto,
-        field: keyof PropertyInputDto,
+        data: PropertyFormData,
+        field: keyof PropertyFormData,
         value: unknown
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, [field]: value };
       };
 
@@ -101,10 +106,10 @@ describe('PropertyForm Component Logic', () => {
 
     it('updates postal code field correctly', () => {
       const updateField = (
-        data: PropertyInputDto,
-        field: keyof PropertyInputDto,
+        data: PropertyFormData,
+        field: keyof PropertyFormData,
         value: unknown
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, [field]: value };
       };
 
@@ -114,10 +119,10 @@ describe('PropertyForm Component Logic', () => {
 
     it('updates build year field correctly', () => {
       const updateField = (
-        data: PropertyInputDto,
-        field: keyof PropertyInputDto,
+        data: PropertyFormData,
+        field: keyof PropertyFormData,
         value: unknown
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, [field]: value };
       };
 
@@ -127,10 +132,10 @@ describe('PropertyForm Component Logic', () => {
 
     it('updates apartment type field correctly', () => {
       const updateField = (
-        data: PropertyInputDto,
-        field: keyof PropertyInputDto,
+        data: PropertyFormData,
+        field: keyof PropertyFormData,
         value: unknown
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, [field]: value };
       };
 
@@ -140,10 +145,10 @@ describe('PropertyForm Component Logic', () => {
 
     it('updates description field correctly', () => {
       const updateField = (
-        data: PropertyInputDto,
-        field: keyof PropertyInputDto,
+        data: PropertyFormData,
+        field: keyof PropertyFormData,
         value: unknown
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, [field]: value };
       };
 
@@ -159,9 +164,9 @@ describe('PropertyForm Component Logic', () => {
   describe('Ownership share update logic', () => {
     it('updates ownership share correctly', () => {
       const updateOwnershipShare = (
-        data: PropertyInputDto,
+        data: PropertyFormData,
         newShare: number
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         if (!data.ownerships || data.ownerships.length === 0) {
           return data;
         }
@@ -176,15 +181,15 @@ describe('PropertyForm Component Logic', () => {
     });
 
     it('preserves userId when updating share', () => {
-      const inputWithUser: PropertyInputDto = {
+      const inputWithUser: PropertyFormData = {
         ...defaultPropertyInput,
         ownerships: [{ userId: 5, share: 100 }],
       };
 
       const updateOwnershipShare = (
-        data: PropertyInputDto,
+        data: PropertyFormData,
         newShare: number
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         if (!data.ownerships || data.ownerships.length === 0) {
           return data;
         }
@@ -203,9 +208,9 @@ describe('PropertyForm Component Logic', () => {
   describe('Photo update logic', () => {
     it('updates photo path correctly', () => {
       const updatePhoto = (
-        data: PropertyInputDto,
+        data: PropertyFormData,
         newPhoto: string | undefined
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, photo: newPhoto };
       };
 
@@ -217,15 +222,15 @@ describe('PropertyForm Component Logic', () => {
     });
 
     it('clears photo correctly', () => {
-      const inputWithPhoto: PropertyInputDto = {
+      const inputWithPhoto: PropertyFormData = {
         ...defaultPropertyInput,
         photo: 'uploads/photos/existing.jpg',
       };
 
       const updatePhoto = (
-        data: PropertyInputDto,
+        data: PropertyFormData,
         newPhoto: string | undefined
-      ): PropertyInputDto => {
+      ): PropertyFormData => {
         return { ...data, photo: newPhoto };
       };
 
@@ -278,7 +283,7 @@ describe('PropertyForm Component Logic', () => {
 
   describe('New vs existing property detection', () => {
     it('identifies new property when id is 0', () => {
-      const isNewProperty = (data: PropertyInputDto): boolean => {
+      const isNewProperty = (data: PropertyFormData): boolean => {
         return data.id === 0;
       };
 
@@ -286,12 +291,12 @@ describe('PropertyForm Component Logic', () => {
     });
 
     it('identifies existing property when id > 0', () => {
-      const existingProperty: PropertyInputDto = {
+      const existingProperty: PropertyFormData = {
         ...defaultPropertyInput,
         id: 5,
       };
 
-      const isNewProperty = (data: PropertyInputDto): boolean => {
+      const isNewProperty = (data: PropertyFormData): boolean => {
         return data.id === 0;
       };
 
@@ -393,7 +398,7 @@ describe('PropertyForm Component Logic', () => {
       setPendingPhoto(file);
 
       expect(pendingPhoto).not.toBeNull();
-      expect(pendingPhoto?.name).toBe('test.jpg');
+      expect((pendingPhoto as unknown as File).name).toBe('test.jpg');
     });
 
     it('pending photo can be cleared', () => {

--- a/frontend/src/components/property/PropertyView.test.tsx
+++ b/frontend/src/components/property/PropertyView.test.tsx
@@ -11,8 +11,8 @@ import { Routes, Route } from 'react-router-dom';
 // Mock the withTranslation HOC
 jest.mock('react-i18next', () => ({
   ...jest.requireActual('react-i18next'),
-  withTranslation: () => (Component: React.ComponentType) => {
-    const WrappedComponent = (props: object) => {
+  withTranslation: () => <P extends { t?: (key: string) => string }>(Component: React.ComponentType<P>) => {
+    const WrappedComponent = (props: Omit<P, 't'>) => {
       const translations: Record<string, string> = {
         viewPageTitle: 'Property Details',
         propertyInfo: 'Property Information',
@@ -32,7 +32,7 @@ jest.mock('react-i18next', () => ({
         ownershipShare: 'Ownership share',
       };
       const t = (key: string) => translations[key] || key;
-      return <Component {...props} t={t} />;
+      return <Component {...(props as P)} t={t} />;
     };
     WrappedComponent.displayName = `withTranslation(${Component.displayName || Component.name})`;
     return WrappedComponent;
@@ -68,7 +68,7 @@ describe('PropertyView', () => {
     apartmentType: '2h+k',
     description: 'A beautiful apartment in the city center.',
     photo: 'uploads/properties/photo1.jpg',
-    ownerships: [{ share: 100 }],
+    ownerships: [{ share: 100, userId: 1, propertyId: 1 }],
   });
 
   beforeEach(() => {
@@ -142,7 +142,7 @@ describe('PropertyView', () => {
     it('shows ownership share with circular badge', async () => {
       const partialOwnership = createMockProperty({
         ...mockProperty,
-        ownerships: [{ share: 75 }],
+        ownerships: [{ share: 75, userId: 1, propertyId: 1 }],
       });
       mockGet.mockResolvedValue(partialOwnership);
 

--- a/frontend/src/components/transaction/components/EditableRows.test.tsx
+++ b/frontend/src/components/transaction/components/EditableRows.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { renderWithProviders } from '@test-utils/test-wrapper';
-import { TransactionType } from '@alisa-types';
+import { TransactionInput, TransactionType } from '@alisa-types';
 import EditableRows from './EditableRows';
 import ApiClient from '@alisa-lib/api-client';
 
@@ -21,17 +21,21 @@ describe('EditableRows', () => {
     accountingDate: new Date().toISOString(),
   };
 
-  const mockTransaction = {
+  const mockTransaction: TransactionInput = {
     id: 1,
     amount: 1000,
     description: 'Test transaction',
+    sender: 'Test Sender',
+    receiver: 'Test Receiver',
+    transactionDate: new Date('2024-01-01'),
+    accountingDate: new Date('2024-01-01'),
     expenses: [],
     incomes: [],
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (ApiClient.getDefault as jest.SpyInstance).mockResolvedValue({ ...mockDefaultRow });
+    (ApiClient.getDefault as unknown as jest.SpyInstance).mockResolvedValue({ ...mockDefaultRow });
   });
 
   afterAll(() => {

--- a/frontend/src/components/transaction/import-wizard/steps/AcceptStep.test.tsx
+++ b/frontend/src/components/transaction/import-wizard/steps/AcceptStep.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import AcceptStep from './AcceptStep';
 import { Transaction, TransactionType, TransactionStatus } from '@alisa-types';
+import { TFunction } from 'i18next';
 
 describe('AcceptStep', () => {
   const mockT = jest.fn((key: string, options?: Record<string, unknown>) => {
@@ -23,7 +24,7 @@ describe('AcceptStep', () => {
       'unknown': 'Unknown',
     };
     return translations[key] || key;
-  });
+  }) as unknown as TFunction;
 
   const mockOnApprove = jest.fn();
   const mockOnNext = jest.fn();

--- a/frontend/src/components/transaction/import-wizard/steps/DoneStep.test.tsx
+++ b/frontend/src/components/transaction/import-wizard/steps/DoneStep.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 import DoneStep from './DoneStep';
 import { ImportStats } from '../types';
 import { TransactionType } from '@alisa-types';
+import { TFunction } from 'i18next';
 
 // Mock useNavigate - must be before importing DoneStep
 const mockNavigate = jest.fn();
@@ -27,7 +28,7 @@ describe('DoneStep', () => {
       'importWizard.viewTransactions': 'Go to Transactions',
     };
     return translations[key] || key;
-  });
+  }) as unknown as TFunction;
 
   const mockOnReset = jest.fn();
 

--- a/frontend/src/components/transaction/import-wizard/steps/ImportStep.test.tsx
+++ b/frontend/src/components/transaction/import-wizard/steps/ImportStep.test.tsx
@@ -6,6 +6,7 @@ import ImportStep from './ImportStep';
 import { BankId } from '../types';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import { TFunction } from 'i18next';
 
 // Create a local server for this test file
 const localServer = setupServer();
@@ -34,7 +35,7 @@ describe('ImportStep', () => {
       'importWizard.skippedRows': `${options?.count ?? 0} transactions were skipped because they have already been imported and approved.`,
     };
     return translations[key] || key;
-  });
+  }) as unknown as TFunction;
 
   const mockOnFilesSelect = jest.fn();
   const mockOnBankSelect = jest.fn();

--- a/frontend/src/components/transaction/import-wizard/steps/ReviewStep.test.tsx
+++ b/frontend/src/components/transaction/import-wizard/steps/ReviewStep.test.tsx
@@ -3,6 +3,7 @@ import { renderWithProviders, screen } from '@test-utils/test-wrapper';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { Transaction, TransactionType, TransactionStatus } from '@alisa-types';
+import { TFunction } from 'i18next';
 
 // Mock TransactionsPendingActions
 jest.mock(
@@ -59,7 +60,7 @@ describe('ReviewStep', () => {
       'search': 'Search',
     };
     return translations[key] || key;
-  });
+  }) as unknown as TFunction;
 
   const mockOnSelectChange = jest.fn();
   const mockOnSelectAllChange = jest.fn();

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -1,7 +1,7 @@
 // Common enums and shared types
 
 // Supported languages for the application
-export const SUPPORTED_LANGUAGES = ['en', 'fi'] as const;
+export const SUPPORTED_LANGUAGES = ['en', 'fi', 'sv'] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
 export enum TransactionStatus {

--- a/frontend/test/utils/test-data.ts
+++ b/frontend/test/utils/test-data.ts
@@ -1,7 +1,5 @@
 // frontend/test/utils/test-data.ts
-import { Property } from '@alisa-backend/real-estate/property/entities/property.entity';
-import { Transaction } from '@alisa-backend/accounting/transaction/entities/transaction.entity';
-import { User } from '@alisa-backend/people/user/entities/user.entity';
+import { Property, Transaction, User, TransactionStatus, TransactionType } from '@alisa-types';
 
 /**
  * Creates a mock Property for testing
@@ -13,13 +11,8 @@ export const createMockProperty = (overrides?: Partial<Property>): Property => {
     address: '123 Test Street',
     postalCode: '00100',
     city: 'Helsinki',
-    country: 'Finland',
-    propertyType: 'APARTMENT',
-    purchasePrice: 250000,
-    purchaseDate: new Date('2020-01-01'),
-    currentValue: 275000,
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    size: 50,
+    ownerships: [],
     ...overrides,
   } as Property;
 };
@@ -30,13 +23,17 @@ export const createMockProperty = (overrides?: Partial<Property>): Property => {
 export const createMockTransaction = (overrides?: Partial<Transaction>): Transaction => {
   return {
     id: 1,
-    amount: 1000,
-    date: new Date('2024-01-01'),
+    externalId: 'ext-001',
+    status: TransactionStatus.PENDING,
+    type: TransactionType.INCOME,
+    sender: 'Test Sender',
+    receiver: 'Test Receiver',
     description: 'Test Transaction',
-    type: 'INCOME',
-    category: 'RENT',
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    transactionDate: new Date('2024-01-01'),
+    accountingDate: new Date('2024-01-01'),
+    amount: 1000,
+    balance: 5000,
+    propertyId: 1,
     ...overrides,
   } as Transaction;
 };
@@ -50,8 +47,6 @@ export const createMockUser = (overrides?: Partial<User>): User => {
     email: 'test@example.com',
     firstName: 'Test',
     lastName: 'User',
-    createdAt: new Date(),
-    updatedAt: new Date(),
     ...overrides,
   } as User;
 };


### PR DESCRIPTION
## Summary

- Fix TFunction mock types across all test files by adding proper i18next type imports and casts
- Fix SpyInstance conversion errors using `unknown` cast pattern
- Fix PropertyInput/PropertyFormData type definitions for form tests
- Fix Ownership interface missing `propertyId` in test data
- Fix TransactionStatus/Type enum usage (use enum values instead of strings)
- Fix language selector to properly type SupportedLanguage (added 'sv')
- Fix dashboard test type narrowing issues with union type casts
- Fix test-data.ts to use frontend types instead of backend entity imports
- Fix various `never` type inference issues with explicit type annotations

## Test plan

- [x] `npm run build` in frontend passes (TypeScript compilation + Vite build)
- [x] All 89 frontend test suites pass (1359 tests)
- [x] Lint passes

Closes #31