### PR TITLE
fix(investment-calculator): remove duplicate success messages

### DIFF
--- a/frontend/src/components/investment-calculator/InvestmentCalculatorProtected.tsx
+++ b/frontend/src/components/investment-calculator/InvestmentCalculatorProtected.tsx
@@ -1,5 +1,5 @@
 import { WithTranslation, withTranslation } from "react-i18next";
-import { Alert, Box, Card, CardContent, Tab, Tabs } from "@mui/material";
+import { Box, Card, CardContent, Tab, Tabs } from "@mui/material";
 import React from "react";
 import { useSearchParams } from "react-router-dom";
 import { AxiosResponse } from "axios";
@@ -16,7 +16,6 @@ function InvestmentCalculatorProtected({ t }: WithTranslation) {
   const [tabValue, setTabValue] = React.useState(0);
   const [results, setResults] = React.useState<InvestmentResults | null>(null);
   const [inputData, setInputData] = React.useState<InvestmentInputData | null>(null);
-  const [saveSuccess, setSaveSuccess] = React.useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const [formKey, setFormKey] = React.useState(0);
   const { showToast } = useToast();
@@ -50,13 +49,11 @@ function InvestmentCalculatorProtected({ t }: WithTranslation) {
   React.useEffect(() => {
     // Check if we just saved successfully
     if (searchParams.get('saved') === 'true') {
-      setSaveSuccess(true);
+      showToast({ message: t("common:toast.calculationSaved"), severity: "success" });
       // Clear the URL parameter
       setSearchParams({}, { replace: true });
-      // Auto-hide success message after 5 seconds
-      setTimeout(() => setSaveSuccess(false), 5000);
     }
-  }, [searchParams, setSearchParams]);
+  }, [searchParams, setSearchParams, showToast, t]);
 
   const handleCalculate = async (data: InvestmentInputData) => {
     try {
@@ -75,8 +72,6 @@ function InvestmentCalculatorProtected({ t }: WithTranslation) {
     }
     try {
       await ApiClient.post('real-estate/investment', inputData);
-      setSaveSuccess(true);
-      setTimeout(() => setSaveSuccess(false), 5000);
       showToast({ message: t("common:toast.calculationSaved"), severity: "success" });
       // Clear form, sessionStorage and switch to saved calculations tab
       setResults(null);
@@ -109,12 +104,6 @@ function InvestmentCalculatorProtected({ t }: WithTranslation) {
         title={t('investment-calculator:pageTitle')}
         description={t('investment-calculator:pageDescription')}
       />
-
-      {saveSuccess && (
-        <Alert severity="success" sx={{ mb: 3 }}>
-          {t('investment-calculator:saveSuccess')}
-        </Alert>
-      )}
 
       <Tabs
         value={tabValue}

--- a/frontend/src/components/investment-calculator/InvestmentCalculatorPublic.tsx
+++ b/frontend/src/components/investment-calculator/InvestmentCalculatorPublic.tsx
@@ -1,5 +1,5 @@
 import { WithTranslation, withTranslation } from "react-i18next";
-import { Alert, Box, Container, Link, Typography } from "@mui/material";
+import { Box, Container, Link, Typography } from "@mui/material";
 import React from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import useIsAuthenticated from "react-auth-kit/hooks/useIsAuthenticated";
@@ -14,7 +14,6 @@ import { useToast } from "../alisa";
 function InvestmentCalculatorPublic({ t }: WithTranslation) {
   const [results, setResults] = React.useState<InvestmentResults | null>(null);
   const [inputData, setInputData] = React.useState<InvestmentInputData | null>(null);
-  const [saveSuccess, setSaveSuccess] = React.useState(false);
   const [loginDialogOpen, setLoginDialogOpen] = React.useState(false);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -33,13 +32,11 @@ function InvestmentCalculatorPublic({ t }: WithTranslation) {
   React.useEffect(() => {
     // Check if we just saved successfully (coming back from login)
     if (searchParams.get('saved') === 'true') {
-      setSaveSuccess(true);
+      showToast({ message: t("common:toast.calculationSaved"), severity: "success" });
       // Clear the URL parameter
       navigate('/investment-calculator', { replace: true });
-      // Auto-hide success message after 5 seconds
-      setTimeout(() => setSaveSuccess(false), 5000);
     }
-  }, [searchParams, navigate]);
+  }, [searchParams, navigate, showToast, t]);
 
   const handleCalculate = async (data: InvestmentInputData) => {
     try {
@@ -69,8 +66,6 @@ function InvestmentCalculatorPublic({ t }: WithTranslation) {
     // Authenticated user - save directly
     try {
       await ApiClient.post('real-estate/investment', inputData);
-      setSaveSuccess(true);
-      setTimeout(() => setSaveSuccess(false), 5000);
       showToast({ message: t("common:toast.calculationSaved"), severity: "success" });
     } catch (error) {
       console.error('Save error:', error);
@@ -126,12 +121,6 @@ function InvestmentCalculatorPublic({ t }: WithTranslation) {
 
       <Box sx={{ py: 6, flexGrow: 1 }}>
         <Container maxWidth="md">
-          {saveSuccess && (
-            <Alert severity="success" sx={{ mb: 3 }}>
-              {t('investment-calculator:saveSuccess')}
-            </Alert>
-          )}
-
           <Box sx={{ mb: 4, textAlign: 'center' }}>
             <Typography variant="h3" component="h1" gutterBottom fontWeight={700}>
               {t('investment-calculator:title')}

--- a/frontend/src/components/landing/LandingPage.tsx
+++ b/frontend/src/components/landing/LandingPage.tsx
@@ -1,7 +1,7 @@
 import { WithTranslation, withTranslation } from "react-i18next";
-import { Alert, Box, Card, Chip, Container, Grid, Link, Typography } from "@mui/material";
+import { Box, Card, Chip, Container, Grid, Link, Typography } from "@mui/material";
 import { useSearchParams } from "react-router-dom";
-import { AlisaButton } from "../alisa";
+import { AlisaButton, useToast } from "../alisa";
 import CalculateIcon from "@mui/icons-material/Calculate";
 import AccountBalanceIcon from "@mui/icons-material/AccountBalance";
 import AssessmentIcon from "@mui/icons-material/Assessment";
@@ -18,18 +18,16 @@ function LandingPage({ t }: WithTranslation) {
   const [loginDialogOpen, setLoginDialogOpen] = React.useState(false);
   const [results, setResults] = React.useState<InvestmentResults | null>(null);
   const [inputData, setInputData] = React.useState<InvestmentInputData | null>(null);
-  const [saveSuccess, setSaveSuccess] = React.useState(false);
   const [searchParams] = useSearchParams();
   const calculatorRef = React.useRef<HTMLDivElement>(null);
+  const { showToast } = useToast();
 
   React.useEffect(() => {
     // Check if we just saved successfully (coming back from login)
     if (searchParams.get('saved') === 'true') {
-      setSaveSuccess(true);
-      // Auto-hide success message after 5 seconds
-      setTimeout(() => setSaveSuccess(false), 5000);
+      showToast({ message: t("common:toast.calculationSaved"), severity: "success" });
     }
-  }, [searchParams]);
+  }, [searchParams, showToast, t]);
 
   const handleLogin = () => {
     setLoginDialogOpen(true);
@@ -352,12 +350,6 @@ function LandingPage({ t }: WithTranslation) {
       {/* Investment Calculator Section */}
       <Box ref={calculatorRef} sx={{ bgcolor: 'background.paper', py: 8 }}>
         <Container maxWidth="md">
-          {saveSuccess && (
-            <Alert severity="success" sx={{ mb: 3 }}>
-              {t('investment-calculator:saveSuccess')}
-            </Alert>
-          )}
-
           <Box sx={{ mb: 4, textAlign: 'center' }}>
             <Typography variant="h3" component="h2" gutterBottom fontWeight={700}>
               {t('investment-calculator:title')}


### PR DESCRIPTION
## Summary
- Replace inline `Alert` components with `AlisaToast` notifications in the investment calculator
- Previously, saving a calculation showed both an inline Alert AND a Toast notification
- Now only the Toast notification is shown, following the user notification guideline

## Changes
- `InvestmentCalculatorProtected.tsx`: Removed `saveSuccess` state and inline Alert, kept toast only
- `InvestmentCalculatorPublic.tsx`: Same changes as above
- `LandingPage.tsx`: Same changes as above (this page also embeds the calculator)

## Test plan
- [x] All frontend tests pass (89 passed)
- [x] ESLint passes
- [x] Build succeeds
- [ ] Manual verification: save a calculation and confirm only one success message appears (Toast at bottom)

Closes #34