### PR TITLE
fix: ownership loss and image serving issues

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,7 +21,7 @@ import { CommonModule } from './common/common.module';
 @Module({
   imports: [
     ServeStaticModule.forRoot({
-      rootPath: join(__dirname, '..', '..', 'uploads'),
+      rootPath: join(__dirname, '..', 'uploads'),
       serveRoot: '/uploads',
     }),
     ConfigModule.forRoot(),

--- a/backend/src/real-estate/property/property.service.spec.ts
+++ b/backend/src/real-estate/property/property.service.spec.ts
@@ -357,6 +357,30 @@ describe('PropertyService', () => {
       expect(result.ownerships[0].userId).toBe(testUser.id);
       expect(result.ownerships[0].share).toBe(75);
     });
+
+    it('handles null address without throwing error', async () => {
+      const existingProperty = createProperty({
+        id: 1,
+        name: 'Test Property',
+      });
+      // Input with address: null (as returned by TypeORM when no address exists)
+      const input = {
+        name: 'Updated Name',
+        size: 50,
+        address: null as unknown as undefined,
+      };
+
+      mockRepository.findOneBy.mockResolvedValue(existingProperty);
+      mockAuthService.hasOwnership.mockResolvedValue(true);
+      mockRepository.save.mockImplementation((entity) =>
+        Promise.resolve(entity),
+      );
+
+      const result = await service.update(testUser, 1, input);
+
+      expect(result.name).toBe('Updated Name');
+      expect(mockRepository.save).toHaveBeenCalled();
+    });
   });
 
   describe('delete', () => {

--- a/backend/src/real-estate/property/property.service.ts
+++ b/backend/src/real-estate/property/property.service.ts
@@ -289,8 +289,8 @@ export class PropertyService {
       });
     }
 
-    // Handle nested address object
-    if (input.address !== undefined) {
+    // Handle nested address object (check both undefined and null)
+    if (input.address !== undefined && input.address !== null) {
       if (
         input.address.street ||
         input.address.city ||

--- a/frontend/src/components/alisa/AlisaCardList.tsx
+++ b/frontend/src/components/alisa/AlisaCardList.tsx
@@ -27,7 +27,7 @@ import { useToast } from "./toast";
 import { TypeOrmFetchOptions } from "../../lib/types";
 import ApiClient from "../../lib/api-client";
 import AlisaContext from "@alisa-lib/alisa-contexts";
-import { VITE_API_URL } from "../../constants";
+import { VITE_BASE_URL } from "../../constants";
 import { Address, DeleteValidationResult } from "@alisa-types";
 import { AxiosError } from "axios";
 
@@ -144,7 +144,7 @@ function AlisaCardList<T extends { id: number }>({
                     component="img"
                     alt={item.name}
                     height="160"
-                    image={item.photo ? `${VITE_API_URL}/${item.photo}` : '/assets/properties/placeholder.svg'}
+                    image={item.photo ? `${VITE_BASE_URL}/${item.photo}` : '/assets/properties/placeholder.svg'}
                     sx={{ objectFit: 'cover' }}
                   />
                   <CardContent sx={{ flexGrow: 1 }}>

--- a/frontend/src/components/property/PropertyPhotoUpload.tsx
+++ b/frontend/src/components/property/PropertyPhotoUpload.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { AlisaButton, useToast } from '../alisa';
 import axios from 'axios';
 import ApiClient from '@alisa-lib/api-client';
-import { VITE_API_URL } from '../../constants';
+import { VITE_API_URL, VITE_BASE_URL } from '../../constants';
 
 interface PropertyPhotoUploadProps {
   propertyId: number;
@@ -135,7 +135,7 @@ const PropertyPhotoUpload: React.FC<PropertyPhotoUploadProps> = ({
   const photoUrl = pendingPreviewUrl
     ? pendingPreviewUrl
     : photoPath
-      ? `${VITE_API_URL}/${photoPath}`
+      ? `${VITE_BASE_URL}/${photoPath}`
       : '/assets/properties/placeholder.svg';
 
   const hasPhoto = pendingMode ? !!pendingFile : !!photoPath;

--- a/frontend/src/components/property/PropertyView.tsx
+++ b/frontend/src/components/property/PropertyView.tsx
@@ -7,7 +7,7 @@ import { Property } from '@alisa-types';
 import ApiClient from '../../lib/api-client';
 import AlisaLoadingProgress from '../alisa/AlisaLoadingProgress';
 import AlisaButton from '../alisa/form/AlisaButton';
-import { VITE_API_URL } from '../../constants';
+import { VITE_BASE_URL } from '../../constants';
 import EditIcon from '@mui/icons-material/Edit';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import SquareFootIcon from '@mui/icons-material/SquareFoot';
@@ -138,7 +138,7 @@ function PropertyView({ t }: WithTranslation) {
   }
 
   const imageUrl = property.photo
-    ? `${VITE_API_URL}/${property.photo}`
+    ? `${VITE_BASE_URL}/${property.photo}`
     : '/assets/properties/placeholder.svg';
 
   const ownershipShare = property.ownerships?.[0]?.share ?? 100;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,1 +1,2 @@
 export const VITE_API_URL = import.meta.env.VITE_API_URL;
+export const VITE_BASE_URL = import.meta.env.VITE_API_URL?.replace(/\/api$/, '') || '';

--- a/frontend/test/mocks/constants.ts
+++ b/frontend/test/mocks/constants.ts
@@ -1,2 +1,3 @@
 // Mock constants for testing
-export const VITE_API_URL = 'http://localhost:3000';
+export const VITE_API_URL = 'http://localhost:3000/api';
+export const VITE_BASE_URL = 'http://localhost:3000';


### PR DESCRIPTION
## Summary
- Fix ownership loss when updating property with null address (backend mapData crashed)
- Fix image serving path for Docker container (ServeStatic path resolution)
- Add VITE_BASE_URL for static file URLs (without /api prefix)

## Root Causes Found
1. **Ownership loss**: When property had no address, TypeORM returned `address: null`. Backend `mapData` only checked `!== undefined`, so `null.street` crashed. But ownerships were already deleted before the crash, causing permanent data loss.

2. **Images not showing**: `ServeStaticModule` path `join(__dirname, '..', '..', 'uploads')` resolved to `/uploads` instead of `/app/uploads` in Docker container.

3. **Image URL wrong**: Frontend used `VITE_API_URL` (includes `/api`) for image URLs, but images are served from `/uploads` (no `/api` prefix).

## Test plan
- [x] Backend tests pass (423 tests)
- [x] Frontend tests pass (1360 tests)
- [x] Verified image serving works locally
- [x] Verified ownership is preserved when updating property with null address