### PR TITLE
feat: add clear button to AlisaTextField

### DIFF
--- a/frontend/src/components/alisa/form/AlisaTextField.test.tsx
+++ b/frontend/src/components/alisa/form/AlisaTextField.test.tsx
@@ -87,4 +87,93 @@ describe('AlisaTextField', () => {
     const textField = container.querySelector('.MuiTextField-root');
     expect(textField).toHaveClass('MuiFormControl-fullWidth');
   });
+
+  describe('clearable', () => {
+    it('shows clear button by default when has value', () => {
+      renderWithProviders(
+        <AlisaTextField
+          label="Test Label"
+          value="Some text"
+          onChange={jest.fn()}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'clear' })).toBeInTheDocument();
+    });
+
+    it('does not show clear button when value is empty', () => {
+      renderWithProviders(
+        <AlisaTextField
+          label="Test Label"
+          value=""
+          onChange={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: 'clear' })).not.toBeInTheDocument();
+    });
+
+    it('does not show clear button when clearable is false', () => {
+      renderWithProviders(
+        <AlisaTextField
+          label="Test Label"
+          value="Some text"
+          clearable={false}
+          onChange={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: 'clear' })).not.toBeInTheDocument();
+    });
+
+    it('does not show clear button when disabled', () => {
+      renderWithProviders(
+        <AlisaTextField
+          label="Test Label"
+          value="Some text"
+          disabled
+          onChange={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: 'clear' })).not.toBeInTheDocument();
+    });
+
+    it('calls onClear when clear button is clicked', async () => {
+      const user = userEvent.setup();
+      const mockOnClear = jest.fn();
+
+      renderWithProviders(
+        <AlisaTextField
+          label="Test Label"
+          value="Some text"
+          onClear={mockOnClear}
+          onChange={jest.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'clear' }));
+
+      expect(mockOnClear).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onChange with empty value when clear is clicked and no onClear provided', async () => {
+      const user = userEvent.setup();
+      const mockOnChange = jest.fn();
+
+      renderWithProviders(
+        <AlisaTextField
+          label="Test Label"
+          value="Some text"
+          onChange={mockOnChange}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'clear' }));
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({ target: { value: '' } })
+      );
+    });
+  });
 });

--- a/frontend/src/components/alisa/form/AlisaTextField.tsx
+++ b/frontend/src/components/alisa/form/AlisaTextField.tsx
@@ -1,5 +1,6 @@
-import { InputAdornment, TextField } from "@mui/material";
-import { ChangeEventHandler, ReactNode } from "react";
+import ClearIcon from "@mui/icons-material/Clear";
+import { IconButton, InputAdornment, TextField } from "@mui/material";
+import React, { ChangeEventHandler, ReactNode } from "react";
 
 interface AlisaTextFieldProps {
   label: string;
@@ -7,6 +8,7 @@ interface AlisaTextFieldProps {
   adornment?: string | ReactNode;
   autoComplete?: string;
   autoFocus?: boolean;
+  clearable?: boolean;
   disabled?: boolean;
   fullWidth?: boolean;
   multiline?: boolean;
@@ -17,16 +19,54 @@ interface AlisaTextFieldProps {
   onChange?:
     | ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>
     | undefined;
+  onClear?: () => void;
   onBlur?: () => void;
   sx?: object;
 }
 
 function AlisaTextField(props: AlisaTextFieldProps) {
-  const adornmentContent = props.adornment
-    ? typeof props.adornment === "string"
-      ? <InputAdornment position="end">{props.adornment}</InputAdornment>
-      : props.adornment
-    : null;
+  const showClearButton =
+    props.clearable !== false && props.value && !props.disabled;
+
+  const handleClear = () => {
+    if (props.onClear) {
+      props.onClear();
+    } else if (props.onChange) {
+      const syntheticEvent = {
+        target: { value: "" },
+      } as React.ChangeEvent<HTMLInputElement>;
+      props.onChange(syntheticEvent);
+    }
+  };
+
+  const clearButton = showClearButton ? (
+    <IconButton
+      size="small"
+      onClick={handleClear}
+      edge="end"
+      aria-label="clear"
+      tabIndex={-1}
+      sx={{
+        padding: 0.25,
+        color: "action.disabled",
+        "&:hover": { color: "action.active" },
+      }}
+    >
+      <ClearIcon sx={{ fontSize: 16 }} />
+    </IconButton>
+  ) : null;
+
+  const adornmentContent =
+    clearButton || props.adornment ? (
+      <InputAdornment
+        position="end"
+        sx={props.multiline ? { mt: 0 } : undefined}
+      >
+        {clearButton}
+        {typeof props.adornment === "string" ? props.adornment : null}
+        {typeof props.adornment !== "string" ? props.adornment : null}
+      </InputAdornment>
+    ) : null;
 
   return (
     <TextField
@@ -49,6 +89,9 @@ function AlisaTextField(props: AlisaTextFieldProps) {
       slotProps={{
         input: {
           endAdornment: adornmentContent,
+          ...(props.multiline && {
+            sx: { alignItems: "flex-start" },
+          }),
         },
       }}
     />


### PR DESCRIPTION
## Summary
- Adds a subtle clear (X) button to text fields that appears when the field has a value
- Button clears the field content when clicked by triggering onChange with empty value
- Enabled by default, can be disabled with `clearable={false}`
- For multiline fields, the button is positioned at the top-right corner
- Subtle styling: small icon, muted color that becomes visible on hover

## Test plan
- [x] Unit tests added for all clear button scenarios (6 new tests)
- [ ] Verify clear button appears in text fields with values
- [ ] Verify clear button clears the field when clicked
- [ ] Verify clear button does not appear when field is empty or disabled
- [ ] Verify clear button position in multiline text areas (top-right corner)