### PR TITLE
feat: enable sorting on finance module datatables

### DIFF
--- a/frontend/src/components/accounting/expenses/Expenses.tsx
+++ b/frontend/src/components/accounting/expenses/Expenses.tsx
@@ -203,6 +203,7 @@ function Expenses({ t }: WithTranslation) {
           <AlisaDataTable<ExpenseRow>
             t={t}
             dataService={rowDataService}
+            sortable
             fields={[
               { name: "accountingDate", format: "date" },
               { name: "expenseTypeName", label: t("expenseType") },

--- a/frontend/src/components/accounting/incomes/Incomes.tsx
+++ b/frontend/src/components/accounting/incomes/Incomes.tsx
@@ -203,6 +203,7 @@ function Incomes({ t }: WithTranslation) {
           <AlisaDataTable<IncomeRow>
             t={t}
             dataService={rowDataService}
+            sortable
             fields={[
               { name: "accountingDate", format: "date" },
               { name: "incomeTypeName", label: t("incomeType") },

--- a/frontend/src/components/transaction/Transactions.tsx
+++ b/frontend/src/components/transaction/Transactions.tsx
@@ -121,6 +121,7 @@ function Transactions({
           dataService={
             new DataService({ context: transactionContext, fetchOptions })
           }
+          sortable
           fields={[
             {
               name: "type",

--- a/frontend/src/components/transaction/import-wizard/steps/ReviewStep.tsx
+++ b/frontend/src/components/transaction/import-wizard/steps/ReviewStep.tsx
@@ -242,6 +242,7 @@ export default function ReviewStep({
         <AlisaDataTable<Transaction>
           t={t}
           data={filteredTransactions}
+          sortable
           fields={[
             {
               name: "type",

--- a/frontend/src/components/transaction/pending/TransactionsPending.tsx
+++ b/frontend/src/components/transaction/pending/TransactionsPending.tsx
@@ -369,6 +369,7 @@ function TransactionsPending({ t }: WithTranslation) {
             dataService={
               new DataService({ context: transactionContext, fetchOptions })
             }
+            sortable
             fields={[
               {
                 name: "type",


### PR DESCRIPTION
## Summary
- Enable column sorting on all finance module datatables
- Incomes, Expenses, Transactions, Pending Transactions, and Import Review tables now support sorting by clicking column headers

## Test plan
- [ ] Navigate to Incomes view and verify column headers are clickable for sorting
- [ ] Navigate to Expenses view and verify column headers are clickable for sorting
- [ ] Navigate to Transactions view and verify sorting works
- [ ] Navigate to Pending Transactions view and verify sorting works
- [ ] Open Import Wizard and verify Review step table supports sorting